### PR TITLE
fix bad route

### DIFF
--- a/src/components/recipe-list/recipe-preview/RecipePreview.tsx
+++ b/src/components/recipe-list/recipe-preview/RecipePreview.tsx
@@ -18,7 +18,7 @@ const RecipePreview = forwardRef(function RecipePreview(
 
   return (
     <Link
-      to={`recipe/${id}`}
+      to={`/recipe/${id}`}
       className={styles.recipe}
       ref={ref as unknown as Ref<HTMLAnchorElement>}
     >


### PR DESCRIPTION
As discussed previously, route should start with `/` otherwise it gets appended to whatever was in the url leading to 404s